### PR TITLE
uploading caching for skaffold artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN ./gradlew clean build release
 
 ################################################################################
 
-FROM centos:centos6
+FROM centos:centos6 as runner
 ENV JAVA_HOME=/usr
 
 # Accept VMware certificate

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -2,19 +2,16 @@ apiVersion: skaffold/v1beta12
 kind: Config
 build:
   artifacts:
-  - image: gradle-builder
+  - image: springtrader
     context: .
     docker:
-      target: builder
-  - image: docker.artifactory.liatr.io/liatrio/springtrader
-    context: .
-    docker:
-      cacheFrom:
-        - gradle-builder
-        - docker.artifactory.liatr.io/liatrio/springtrader
+      target: runner
+      buildArgs:
+        target: runner
+        tag: docker.artifactory.liatr.io/liatrio/springtrader:latest
+        cache-from: gradle-builder,docker.artifactory.liatr.io/liatrio/springtrader
   - image: sqlfdb 
     context: ./sqlfdb
-
   local: {}
 
 deploy:

--- a/skaffold.yml
+++ b/skaffold.yml
@@ -1,12 +1,19 @@
-apiVersion: skaffold/v1alpha2
+apiVersion: skaffold/v1beta12
 kind: Config
 build:
   artifacts:
-  - imageName: springtrader 
-    workspace: .
-
-  - imageName: sqlfdb 
-    workspace: ./sqlfdb
+  - image: gradle-builder
+    context: .
+    docker:
+      target: builder
+  - image: docker.artifactory.liatr.io/liatrio/springtrader
+    context: .
+    docker:
+      cacheFrom:
+        - gradle-builder
+        - docker.artifactory.liatr.io/liatrio/springtrader
+  - image: sqlfdb 
+    context: ./sqlfdb
 
   local: {}
 
@@ -16,5 +23,5 @@ deploy:
       - name: springtrader 
         chartPath: ./charts/springtrader
         values:
-          image: springtrader 
+          image: docker.artifactory.liatr.io/liatrio/springtrader 
           sqlfdb: sqlfdb 


### PR DESCRIPTION
Skaffold will prune by default. In order to run builds or deployments with the cache, you will need to pass in the `--cache-artifacts` flag.

Examples:
`skaffold build --cache-artifacts`
then
`skaffold dev --cache-artifacts`