### PR TITLE
Added 30 minute timeout to manual check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,9 @@ pipeline {
 
     /// [gate]
     stage ('Manual Ready Check') {
+      options {
+        timeout(time: 30, unit: 'MINUTES')
+      }
       when {
         branch 'master'
       }


### PR DESCRIPTION
This PR sets a time limit for the *Manual Ready Check* stage in the pipeline. This prevent hanging pipelines for those who either forget about their build or don't have permission to abort the build.