### PR TITLE
Solution2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,9 @@ pipeline {
   stages {
     /// [build]
     stage('Build') {
+      when {
+          branch 'master'
+      }
       steps {
         notifyPipelineStart()
         notifyStageStart()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
     }
     /// [stage]
 
-    /// [gate]
+/*    /// [gate]
     stage ('Manual Ready Check') {
       when {
         branch 'master'
@@ -95,6 +95,7 @@ pipeline {
       }
     }
     /// [prod]
+  */
   }
   post {
     success {


### PR DESCRIPTION
When a new fork is cut, and added to sparky, Solution 2 runs as part of the addition.

This change will make it so that solution2 branch is not ran, and doesn't hold an executor.

Commented out Gate and Production. Does it make sense to have these steps when "Proceed or Abort" comes up if a participant can't log in to Jenkins to do this? What is the value add?