### PR TITLE
Removing cleanup image.json after its stashed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
         container('skaffold') {
           sh "skaffold build --file-output=image.json"
           stash includes: 'image.json', name: 'build'
+          sh "rm image.json"
         }
       }
       post {


### PR DESCRIPTION
This should get around our problem of running on the same skaffold node.