### PR TITLE
AWS Ignite Validation Tests

### DIFF
--- a/tests/lab01_test.go
+++ b/tests/lab01_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Lab 1", func() {
 
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			ConcatenatedMessage += failMessage
+			ConcatenatedMessage = ConcatenatedMessage + failMessage + "\n"
 		}
 	})
 })

--- a/tests/lab02_test.go
+++ b/tests/lab02_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Lab 2", func() {
+var _ = Describe("Lab 2 jenkins", func() {
 	var failMessage string
 
 	BeforeEach(func() {
@@ -47,6 +47,108 @@ var _ = Describe("Lab 2", func() {
 	AfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
 			ConcatenatedMessage += failMessage
+		}
+	})
+})
+
+var _ = Describe("Lab 2 aws", func() {
+	var failMessage string
+
+	BeforeEach(func() {
+		failMessage = ""
+	})
+
+	Context("Step 1", func() {
+		It("should have a skaffold.yaml file", func() {
+			failMessage = "skaffold.yaml doesn't exist or is in the wrong location\n"
+			Expect("../skaffold.yaml").To(BeAnExistingFile(), failMessage)
+		})
+		It("should have a valid skaffold.yaml", func() {
+			skaffoldExpected, errorMessage := ExpectYamlToParse("../skaffold.yaml")
+			if errorMessage != "" {
+				failMessage = errorMessage
+			}
+			Expect(errorMessage).To(BeEmpty(), failMessage)
+			failMessage = fmt.Sprintf("Your skaffold.yaml seems to empty. Try again after configuring your file\n")
+			Expect(skaffoldExpected).ToNot(BeNil(), failMessage)
+			skaffoldActual, _ := ExpectYamlToParse("./validate/solution-data/lab02/step01-skaffold.yaml")
+			_, err := ValidateYamlObject(skaffoldExpected, &failMessage).Match(skaffoldActual)
+			if err != nil {
+				failMessage = fmt.Sprintf("skaffold.yaml has incorrect configuration; %s\n", err.Error())
+			}
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Step 3.2", func() {
+		It("should have a Build buildspec file", func() {
+			failMessage = "Build buildspec doesn't exist or is in the wrong location\n"
+			Expect("../buildspec-build.yaml").To(BeAnExistingFile(), failMessage)
+		})
+		It("should have a valid Build buildspec", func() {
+			skaffoldExpected, errorMessage := ExpectYamlToParse("../buildspec-build.yaml")
+			if errorMessage != "" {
+				failMessage = errorMessage
+			}
+			Expect(errorMessage).To(BeEmpty(), failMessage)
+			failMessage = fmt.Sprintf("Your buildspec-build.yaml seems to empty. Try again after configuring your file\n")
+			Expect(skaffoldExpected).ToNot(BeNil(), failMessage)
+			skaffoldActual, _ := ExpectYamlToParse("./validate/solution-data/lab02/step03-build-buildspec.yaml")
+			_, err := ValidateYamlObject(skaffoldExpected, &failMessage).Match(skaffoldActual)
+			if err != nil {
+				failMessage = fmt.Sprintf("buildspec-build.yaml has incorrect configuration; %s\n", err.Error())
+			}
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Step 3.3", func() {
+		It("should have a Staging buildspec file", func() {
+			failMessage = "Staging buildspec doesn't exist or is in the wrong location\n"
+			Expect("../buildspec-staging.yaml").To(BeAnExistingFile(), failMessage)
+		})
+		It("should have a valid Staging buildspec", func() {
+			skaffoldExpected, errorMessage := ExpectYamlToParse("../buildspec-staging.yaml")
+			if errorMessage != "" {
+				failMessage = errorMessage
+			}
+			Expect(errorMessage).To(BeEmpty(), failMessage)
+			failMessage = fmt.Sprintf("Your buildspec-staging.yaml seems to empty. Try again after configuring your file\n")
+			Expect(skaffoldExpected).ToNot(BeNil(), failMessage)
+			skaffoldActual, _ := ExpectYamlToParse("./validate/solution-data/lab02/step03-staging-buildspec.yaml")
+			_, err := ValidateYamlObject(skaffoldExpected, &failMessage).Match(skaffoldActual)
+			if err != nil {
+				failMessage = fmt.Sprintf("buildspec-staging.yaml has incorrect configuration; %s\n", err.Error())
+			}
+			Expect(err).To(BeNil())
+		})
+	})
+
+	Context("Step 3.5", func() {
+		It("should have a Prod buildspec file", func() {
+			failMessage = "Prod buildspec doesn't exist or is in the wrong location\n"
+			Expect("../buildspec-prod.yaml").To(BeAnExistingFile(), failMessage)
+		})
+		It("should have a valid Prod buildspec", func() {
+			skaffoldExpected, errorMessage := ExpectYamlToParse("../buildspec-prod.yaml")
+			if errorMessage != "" {
+				failMessage = errorMessage
+			}
+			Expect(errorMessage).To(BeEmpty(), failMessage)
+			failMessage = fmt.Sprintf("Your buildspec-prod.yaml seems to empty. Try again after configuring your file\n")
+			Expect(skaffoldExpected).ToNot(BeNil(), failMessage)
+			skaffoldActual, _ := ExpectYamlToParse("./validate/solution-data/lab02/step03-prod-buildspec.yaml")
+			_, err := ValidateYamlObject(skaffoldExpected, &failMessage).Match(skaffoldActual)
+			if err != nil {
+				failMessage = fmt.Sprintf("buildspec-prod.yaml has incorrect configuration; %s\n", err.Error())
+			}
+			Expect(err).To(BeNil())
+		})
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			ConcatenatedMessage = ConcatenatedMessage + failMessage + "\n"
 		}
 	})
 })

--- a/tests/validate/solution-data/lab02/step03-build-buildspec.yaml
+++ b/tests/validate/solution-data/lab02/step03-build-buildspec.yaml
@@ -1,0 +1,19 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+  pre_build:
+    commands:
+      -  aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $PRODUCT_IMAGE_REPO
+  build:
+    commands:
+      - skaffold build --file-output=image.json --tag $CODEBUILD_RESOLVED_SOURCE_VERSION
+artifacts:
+  files:
+    - image.json
+    - skaffold.yaml
+    - buildspec-staging.yaml
+    - buildspec-prod.yaml
+    - charts/**/*

--- a/tests/validate/solution-data/lab02/step03-prod-buildspec.yaml
+++ b/tests/validate/solution-data/lab02/step03-prod-buildspec.yaml
@@ -1,0 +1,8 @@
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - aws eks update-kubeconfig --name $CLUSTER
+  build:
+    commands:
+      - skaffold deploy -a image.json -n $PROD_NAMESPACE

--- a/tests/validate/solution-data/lab02/step03-staging-buildspec.yaml
+++ b/tests/validate/solution-data/lab02/step03-staging-buildspec.yaml
@@ -1,0 +1,8 @@
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - aws eks update-kubeconfig --name $CLUSTER
+  build:
+    commands:
+      - skaffold deploy -a image.json -n $STAGING_NAMESPACE


### PR DESCRIPTION
* adding tests for aws ignite labs + error handling for mismatched keys of files
* Uses the ginko selector for lab 2, ie 
- go test -ginkgo.focus="Lab 2 jenkins"
- go test -ginkgo.focus="Lab 2 aws"
* added a newline between error messages to make it easier to read in slack

